### PR TITLE
Added arm64 support to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,12 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: darwin
+        goarch: arm64
 
 changelog:
   skip: true


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal
**PR change Details:**
#**Patch Details :** Following 1 file has been modified :

.goreleaser.yml : arm64 goarch has been added, and jobs for darwin/arm64 and windows/arm64 have been ignored. This will create linux/arm64 release along with other amd64 releases.
#**Testing Detail :**
Please find my arm64 release here : https://github.com/rahulgit-ps/bfe/releases
We need to install goreleaser on our system, generate and set the GITHUB_TOKEN, generate a tag and push it to our forked repo. Then in the root of our repo, we need to run 'goreleaser' command. That will upload releases to our forked repo.
#**Reviewer Comment :** < To be filled by Reviewer >
#**PR Description :** Here is my commit message :
Updated the .goreleaser.yml file to generate linux/arm64 release for bfe.

Signed-off-by: odidev <odidev@puresoftware.com>
#**Reviewer Comment :** < To be filled by Reviewer >
#**Peer Reviewer:** Pruthvi Teja
#**Reviewer:** Rajeev Nayan
**Thanks
Rahul Aggarwal**